### PR TITLE
Fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This runtime provides Kotlin running on the following OpenJDK/OpenJ9 image from [AdoptOpenJDK](https://adoptopenjdk.net/?variant=openjdk8-openj9):
 
- *  [adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u162-b12_openj9-0.8.0](https://hub.docker.com/r/adoptopenjdk/openjdk8-openj9/)
+ *  [adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u212-b04_openj9-0.14.2](https://hub.docker.com/r/adoptopenjdk/openjdk8-openj9/)
 
 ## Creating a Kotlin Action
 

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -14,7 +14,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u162-b12_openj9-0.8.0
+FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u212-b04_openj9-0.14.2
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales \
@@ -25,8 +25,8 @@ ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \
 	LC_ALL="en_US.UTF-8" \
 	VERSION=8 \
-	UPDATE=162 \
-	BUILD=12
+	UPDATE=212 \
+	BUILD=04
 
 ADD proxy /kotlinAction
 

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -15,12 +15,12 @@ IMAGE_PREFIX="testing"
 cd $WHISKDIR
 
 #pull down images
-docker pull openwhisk/controller
-docker tag openwhisk/controller ${IMAGE_PREFIX}/controller
-docker pull openwhisk/invoker
-docker tag openwhisk/invoker ${IMAGE_PREFIX}/invoker
-docker pull openwhisk/nodejs6action
-docker tag openwhisk/nodejs6action ${IMAGE_PREFIX}/nodejs6action
+docker pull openwhisk/controller:nightly
+docker tag openwhisk/controller:nightly ${IMAGE_PREFIX}/controller
+docker pull openwhisk/invoker:nightly
+docker tag openwhisk/invoker:nightly ${IMAGE_PREFIX}/invoker
+docker pull openwhisk/nodejs6action:nightly
+docker tag openwhisk/nodejs6action:nightly ${IMAGE_PREFIX}/nodejs6action
 
 TERM=dumb ./gradlew install
 


### PR DESCRIPTION
  * Update to openjdk8-openj9:x86_64-ubuntu-jdk8u212-b04_openj9-0.14.2. The previous image version was not supported anymore and caused build to break.
  * Adapt to 'nightly' tagged builds.